### PR TITLE
chore: remove `styfle/cancel-workflow-action` usage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
       - dev
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: write
   contents: read
@@ -16,9 +20,6 @@ jobs:
     name: ⬣ ESLint
     runs-on: ubuntu-latest
     steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -39,9 +40,6 @@ jobs:
     name: ʦ TypeScript
     runs-on: ubuntu-latest
     steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -63,9 +61,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -110,9 +105,6 @@ jobs:
     if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
 
     steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,66 +102,11 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-  build:
-    name: 🐳 Build
-    # Only build / deploy main branch on pushes.
-    if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
-
-      - name: 👀 Read app name
-        uses: SebRollen/toml-action@v1.0.2
-        id: app_name
-        with:
-          file: 'fly.toml'
-          field: 'app'
-
-      - name: 🐳 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: v0.9.1
-
-      - name: ⚡️ Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: 🔑 Fly Registry Auth
-        uses: docker/login-action@v2
-        with:
-          registry: registry.fly.io
-          username: x
-          password: ${{ secrets.FLY_API_TOKEN }}
-
-      - name: 🐳 Docker build
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.ref_name }}-${{ github.sha }}
-          build-args: |
-            COMMIT_SHA=${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      - name: 🚚 Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
   deploy:
     name: 🚀 Deploy
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, playwright, build]
-    # Only build / deploy main branch on pushes.
+    needs: [lint, typecheck, playwright]
+    # Only build / deploy main/dev branch on pushes.
     if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
 
     steps:
@@ -175,13 +120,13 @@ jobs:
         uses: SebRollen/toml-action@v1.0.2
         id: app_name
         with:
-          file: 'fly.toml'
-          field: 'app'
+          file: fly.toml
+          field: app
 
       - name: 🚀 Deploy Production
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: superfly/flyctl-actions@1.3
         with:
-          args: 'deploy --image registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.ref_name }}-${{ github.sha }}'
+          args: deploy --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --app ${{ steps.app_name.outputs.value }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,11 @@
 name: 🚀 Deploy
+
 on:
   push:
     branches:
       - main
       - dev
-  pull_request: {}
+  pull_request:
 
 permissions:
   actions: write
@@ -15,46 +16,46 @@ jobs:
     name: ⬣ ESLint
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
+      - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
 
-      - name: Checkout Repository
+      - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup Node
+      - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          cache: npm
+          cache-dependency-path: ./package.json
+          node-version: 18
 
-      - name: Install Dependencies
-        uses: bahmutov/npm-install@v1
-        with:
-          useLockFile: false
+      - name: 📥 Install deps
+        run: npm install
 
-      - name: Run Lint
+      - name: 🔬 Lint
         run: npm run lint
 
   typecheck:
     name: ʦ TypeScript
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
+      - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
 
-      - name: Checkout Repository
+      - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup Node
+      - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          cache: npm
+          cache-dependency-path: ./package.json
+          node-version: 18
 
-      - name: Install Dependencies
-        uses: bahmutov/npm-install@v1
-        with:
-          useLockFile: false
+      - name: 📥 Install deps
+        run: npm install
 
-      - name: Run Typechecking
+      - name: 🔎 Type check
         run: npm run typecheck --if-present
 
   playwright:
@@ -62,32 +63,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Cancel Previous Runs
+      - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
 
-      - name: Checkout Repository
+      - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Copy Environment Variables
-        run: cp .env.example .env
-
-      - name: Setup Node
+      - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          cache: npm
+          cache-dependency-path: ./package.json
+          node-version: 18
 
-      - name: Install Dependencies
-        uses: bahmutov/npm-install@v1
-        with:
-          useLockFile: false
+      - name: 📥 Install deps
+        run: npm install
+
+      - name: 🏄 Copy test env vars
+        run: cp .env.example .env
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
 
-      - name: Setup Database
+      - name: 🛠 Setup Database
         run: npx prisma migrate reset --force --skip-seed
 
-      - name: Build
+      - name: ⚙️ Build
         run: npm run build
 
       - name: Run Playwright Tests
@@ -107,25 +108,25 @@ jobs:
     if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
+      - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
 
-      - name: Checkout Repository
+      - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Read App Name
+      - name: 👀 Read app name
         uses: SebRollen/toml-action@v1.0.2
         id: app_name
         with:
           file: 'fly.toml'
           field: 'app'
 
-      - name: Set up Docker Buildx
+      - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
           version: v0.9.1
 
-      - name: Cache Docker Layers
+      - name: ⚡️ Cache Docker layers
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
@@ -133,14 +134,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Fly Registry Auth
+      - name: 🔑 Fly Registry Auth
         uses: docker/login-action@v2
         with:
           registry: registry.fly.io
           username: x
           password: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Docker build
+      - name: 🐳 Docker build
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -151,7 +152,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 
-      - name: Move Cache
+      - name: 🚚 Move cache
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
@@ -164,20 +165,20 @@ jobs:
     if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
 
     steps:
-      - name: Cancel Previous Runs
+      - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
 
-      - name: Checkout Repository
+      - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
-      - name: Read App Name
+      - name: 👀 Read app name
         uses: SebRollen/toml-action@v1.0.2
         id: app_name
         with:
           file: 'fly.toml'
           field: 'app'
 
-      - name: Deploy Production
+      - name: 🚀 Deploy Production
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: superfly/flyctl-actions@1.3
         with:


### PR DESCRIPTION
See https://github.com/remix-run/indie-stack/pull/227, https://github.com/remix-run/blues-stack/pull/179, https://github.com/remix-run/grunge-stack/pull/144 & https://github.com/remix-run/react-router-website/pull/52

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
- https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency
- > The fully-formed ref of the branch or tag that triggered the workflow run. For workflows triggered by `push`, this is the branch or tag ref that was pushed. For workflows triggered by `pull_request`, this is the pull request merge branch. For workflows triggered by `release`, this is the release tag created. For other triggers, this is the branch or tag ref that triggered the workflow run. This is only set if a branch or tag is available for the event type. The ref given is fully-formed, meaning that for branches the format is `refs/heads/<branch_name>`, for pull requests it is `refs/pull/<pr_number>/merge`, and for tags it is `refs/tags/<tag_name>`. For example, `refs/heads/feature-branch-1`.
  
  https://docs.github.com/en/actions/learn-github-actions/contexts#github-context